### PR TITLE
Correction to func samples_to_volts

### DIFF
--- a/codes/ecg-image-generator/helper_functions.py
+++ b/codes/ecg-image-generator/helper_functions.py
@@ -174,7 +174,7 @@ def create_signal_dictionary(signal,full_leads):
 
 def samples_to_volts(signal,adc_gain):
     signal_threshold = 10
-    if(np.max(signal))>10:
+    if(np.max(np.abs(signal)))>10:
         signal = signal/adc_gain
     return signal
 


### PR DESCRIPTION
current function doesn't consider signal values bellow zero, which won't scale the signal and produce an error when writing the new header.

This is a solution to the potential bug described in issue #10 