### PR TITLE
ecg gen: bug fix - varible use before declaration

### DIFF
--- a/codes/ecg-image-generator/gen_ecg_image_from_data.py
+++ b/codes/ecg-image-generator/gen_ecg_image_from_data.py
@@ -190,6 +190,8 @@ def run_single_file(args):
                     temp = random.choice(range(2000,4000))
                 else:
                     temp = random.choice(range(10000,20000))
+
+                rotate = args.rotate
             
                 out = get_augment(out,output_directory=args.output_directory,rotate=args.rotate,noise=noise,crop=crop,temperature=temp,bbox = args.bbox, store_text_bounding_box = args.store_text_bounding_box)
             


### PR DESCRIPTION
Code will crash when augment is True due to variable ‘rotate’ not being declared.
