### PR TITLE
Implement backwards compatible color temperature management patch

### DIFF
--- a/codes/ecg-image-generator/README.md
+++ b/codes/ecg-image-generator/README.md
@@ -143,11 +143,10 @@ The basic mode of the tool creates ECG images without distortions. The mode of o
      - `-rot`: Rotation angle by which images can be rotated; default: 0; type: int
      - `-noise`: Noise levels to be added; default: 50; type: int
      - `-c`: Percentage by which image will be cropped; default: 0.01; type: int
-     - `-t`: Colour temperature changes to be added to the image; default: 40000; type: int
+     - `-t`: Sets the deterministic temperature level to all images. If omitted, sets colour temperature per image to random value in one of two ranges - 2000-4000 K (warmer, yellow and orange hues) and 10000-20000 K (colder, blue hues); Neutral white: 6500K; type: int
      - `--deterministic_rot`: Adds the given amount of rotation to all images deterministically. If False, chooses rotation angles randomly in the given range; default: False
      - `--deterministic_noise`: Adds the noise level given detreministcally to all images. If False, adds random amounts of noise in the given range; default: False
      - `--deterministic_crop`: Adds the given level of crop to all images deterministically. If False, adds random crop levels; default: False
-     - `--deterministic_temp`: Adds the deterministic temperature level to all images. If False, adds random colour temepratures in that range; default- False
 
      **Example:**
 

--- a/codes/ecg-image-generator/gen_ecg_image_from_data.py
+++ b/codes/ecg-image-generator/gen_ecg_image_from_data.py
@@ -47,7 +47,7 @@ def get_parser():
     parser.add_argument('-rot','--rotate',type=int,default=0)
     parser.add_argument('-noise','--noise',type=int,default=50)
     parser.add_argument('-c','--crop',type=float,default=0.01)
-    parser.add_argument('-t','--temperature',type=int,default=40000)
+    parser.add_argument('-t','--temperature',type=int)
 
     parser.add_argument('--random_resolution',action="store_true",default=False)
     parser.add_argument('--random_padding',action="store_true",default=False)
@@ -201,6 +201,11 @@ def run_single_file(args):
                     temp = random.choice(range(2000,4000))
                 else:
                     temp = random.choice(range(10000,20000))
+                
+                # Set deterministic temperature when passed as argument
+                if args.temperature:
+                    temp = args.temperature
+                
                 rotate = args.rotate
                 out = get_augment(out,output_directory=args.output_directory,rotate=args.rotate,noise=noise,crop=crop,temperature=temp,bbox = args.lead_bbox, store_text_bounding_box = args.lead_name_bbox, json_dict = json_dict)
             

--- a/codes/ecg-image-generator/gen_ecg_images_from_data_batch.py
+++ b/codes/ecg-image-generator/gen_ecg_images_from_data_batch.py
@@ -38,7 +38,7 @@ def get_parser():
     parser.add_argument('-rot','--rotate',type=int,default=0)
     parser.add_argument('-noise','--noise',type=int,default=50)
     parser.add_argument('-c','--crop',type=float,default=0.01)
-    parser.add_argument('-t','--temperature',type=int,default=40000)
+    parser.add_argument('-t','--temperature',type=int)
 
     parser.add_argument('--random_resolution',action="store_true",default=False)
     parser.add_argument('--random_padding',action="store_true",default=False)


### PR DESCRIPTION
The image colour temperature is not implemented as documented. The `--temperature / -t` and `--deterministic_temperature` flag are not regarded in the code. Since all examples and existing code do not use either flag I implemented it in a backwards compatible, user friendly and still intuitive way. If you set the temperature via flag, it will regarded and else the old random temperature value behaviour remains.

Also 6500 would be a far more reasonable default value (neutral white) and is also used in `codes/ecg-image-generator/ImageAugmentation/augment.py`.